### PR TITLE
Replace mission, deprecate COVID-19 Response Team

### DIFF
--- a/content/post/2020-08-10-hello-world.Rmd
+++ b/content/post/2020-08-10-hello-world.Rmd
@@ -55,7 +55,7 @@ and the real-time epidemiological data server we've been deploying since 2016,
 check out [our website](https://delphi.cmu.edu).
 
 When the COVID-19 pandemic arrived, we focused all our attention on it.
-Our Delphi COVID-19 Response Team was born, 
+Our Delphi team
 quickly grew to 30+ members, and is still growing.
 Most of our members are volunteers,
 drawing talent from within CMU and several other universities,
@@ -64,7 +64,7 @@ The pace has been intense and dizzying at times,
 and we're infinitely grateful for the contributions
 and commitment of all our new members---we'd be nowhere without them.
 See [here](https://covidcast.cmu.edu/covid19-response-team.html)
-for a list of the Delphi COVID-19 Response Team members.
+for a list of the Delphi team members.
 
 With new members comes a new breadth of expertise:
 our expertise now covers statistical modeling, computation,
@@ -78,8 +78,9 @@ especially our longstanding relationship with the CDC.
 
 ## Our Mission and Strategy
 
-The mission of the Delphi COVID-19 Response Team is
-to help combat the COVID-19 pandemic and save lives and livelihoods.
+While Delphi's long-term mission remains to advance the theory and practice of
+epidemic forecasting, since March 2020 our goals are to help combat the COVID-19
+pandemic and save lives and livelihoods.
 We aim to support informed decision-making at federal,
 state, and local levels of government and in the healthcare sector.
 Whenever possible, we strive to make our work useful 

--- a/public/2020/08/10/hello-world/index.html
+++ b/public/2020/08/10/hello-world/index.html
@@ -164,7 +164,7 @@ including some papers we’ve written, software tools we’ve built,
 and the real-time epidemiological data server we’ve been deploying since 2016,
 check out <a href="https://delphi.cmu.edu">our website</a>.</p>
 <p>When the COVID-19 pandemic arrived, we focused all our attention on it.
-Our Delphi COVID-19 Response Team was born,
+Our Delphi team
 quickly grew to 30+ members, and is still growing.
 Most of our members are volunteers,
 drawing talent from within CMU and several other universities,
@@ -173,7 +173,7 @@ The pace has been intense and dizzying at times,
 and we’re infinitely grateful for the contributions
 and commitment of all our new members—we’d be nowhere without them.
 See <a href="https://covidcast.cmu.edu/covid19-response-team.html">here</a>
-for a list of the Delphi COVID-19 Response Team members.</p>
+for a list of the Delphi team members.</p>
 <p>With new members comes a new breadth of expertise:
 our expertise now covers statistical modeling, computation,
 systems engineering, user interfaces, visualization,
@@ -186,8 +186,9 @@ especially our longstanding relationship with the CDC.</p>
 </div>
 <div id="our-mission-and-strategy" class="section level2">
 <h2>Our Mission and Strategy</h2>
-<p>The mission of the Delphi COVID-19 Response Team is
-to help combat the COVID-19 pandemic and save lives and livelihoods.
+<p>While Delphi’s long-term mission remains to advance the theory and practice of
+epidemic forecasting, since March 2020 our goals are to help combat the COVID-19
+pandemic and save lives and livelihoods.
 We aim to support informed decision-making at federal,
 state, and local levels of government and in the healthcare sector.
 Whenever possible, we strive to make our work useful


### PR DESCRIPTION
The Response Team is just the Delphi team.

@RoniRos and @ryantibs, this addresses your suggestions from yesterday; if it looks good, let me know and I'll regenerate the HTML and then merge this.