### PR TITLE
Compress blog posts, images, and JavaScript

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,7 @@
+# Compress posts, their contents, their images
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/html application/javascript text/css image/svg+xml
+</IfModule>
+<IfModule mod_brotli.c>
+    AddOutputFilterByType BROTLI_COMPRESS text/html application/javascript text/css image/svg+xml
+</IfModule>

--- a/deploy.json
+++ b/deploy.json
@@ -9,7 +9,7 @@
        "src": "public/",
        "dst": "/var/www/html/blog/",
        "recursive": true,
-       "match": "^.*\\.(html|css|xml|js|jpg|png|svg|woff|ttf|woff2)$"
+       "match": "^.*\\.(html|css|xml|js|jpg|png|svg|woff|ttf|woff2|htaccess)$"
      }
   ]
 }

--- a/deploy.json
+++ b/deploy.json
@@ -9,7 +9,14 @@
        "src": "public/",
        "dst": "/var/www/html/blog/",
        "recursive": true,
-       "match": "^.*\\.(html|css|xml|js|jpg|png|svg|woff|ttf|woff2|htaccess)$"
+       "match": "^.*\\.(html|css|xml|js|jpg|png|svg|woff|ttf|woff2)$"
      }
+    "// htaccess",
+    {
+      "type": "move",
+      "src": "public/.htaccess",
+      "dst": "/var/www/html/blog/.htaccess",
+      "add-header-comment": true
+    },
   ]
 }

--- a/deploy.json
+++ b/deploy.json
@@ -4,19 +4,19 @@
   "actions": [
 
     "// web sources",
-     {
-       "type": "move",
-       "src": "public/",
-       "dst": "/var/www/html/blog/",
-       "recursive": true,
-       "match": "^.*\\.(html|css|xml|js|jpg|png|svg|woff|ttf|woff2)$"
-     }
+    {
+      "type": "move",
+      "src": "public/",
+      "dst": "/var/www/html/blog/",
+      "recursive": true,
+      "match": "^.*\\.(html|css|xml|js|jpg|png|svg|woff|ttf|woff2)$"
+    },
     "// htaccess",
     {
       "type": "move",
       "src": "public/.htaccess",
       "dst": "/var/www/html/blog/.htaccess",
       "add-header-comment": true
-    },
+    }
   ]
 }

--- a/deploy.json
+++ b/deploy.json
@@ -14,7 +14,7 @@
     "// htaccess",
     {
       "type": "move",
-      "src": "public/.htaccess",
+      "src": ".htaccess",
       "dst": "/var/www/html/blog/.htaccess",
       "add-header-comment": true
     }


### PR DESCRIPTION
Some of our posts are over 5MB from the SVGs, big JavaScript files (KaTeX in particular), and so on. This should tone it down.

I've tested this on the staging server and it deploys without issue and cuts some of the pages down by 50% in size.

The new post in #26 will benefit from this a lot, since it use Plotly, which seems to be distributed as a 3MB (!!!) minified JS file.