### PR TITLE
Fix geo_type attr dependency

### DIFF
--- a/content/post/2020-08-26-fb-survey.Rmd
+++ b/content/post/2020-08-26-fb-survey.Rmd
@@ -129,7 +129,8 @@ df_in_avg = df_in %>% group_by(geo_value) %>% summarize(value = mean(value))
 # Set a bunch of fields so that the data frames know how to plot themselves
 df_fb_avg$time_value = df_in_avg$time_value = start_day
 df_fb_avg$issue = df_in_avg$issue = start_day
-attributes(df_fb_avg)$geo_type = attributes(df_in_avg)$geo_type = "state"
+attributes(df_fb_avg)$metadata$geo_type = "state"
+attributes(df_in_avg)$metadata$geo_type = "state"
 class(df_fb_avg) = c("covidcast_signal", class(df_fb_avg))
 class(df_in_avg) = c("covidcast_signal", class(df_in_avg))
 
@@ -518,7 +519,8 @@ order to estimate % CLI and % CLI-in-community signals there.
 # Set a bunch of fields so that the data frames know how to plot themselves
 df_cor1$time_value = df_cor2$time_value = start_day
 df_cor1$issue = df_cor2$issue = start_day
-attributes(df_cor1)$geo_type = attributes(df_cor2)$geo_type = "county"
+attributes(df_cor1)$metadata$geo_type = "county"
+attributes(df_cor2)$metadata$geo_type = "county"
 class(df_cor1) = class(df_cor2) = c("covidcast_signal", "data.frame")
 
 # Plot choropleth maps, using the covidcast plotting functionality


### PR DESCRIPTION
@capnrefsmmat Now that I got rid of `geo_type` as an attribute for a `covidcast_signal` object in https://github.com/cmu-delphi/covidcast/pull/156, we have to modify the code in this blog post just a tiny bit, since it pieces together a data frame that knows how to "plot itself" using `plot.covidcast_signal()`. 

Once https://github.com/cmu-delphi/covidcast/pull/156 gets merged into main, you can merge this PR.

cc @tildechris I think you were using this code at one point as an example of how to set up a data frame that knows how to "plot itself", just a heads up.